### PR TITLE
terra: remove oracle vote transaction batching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 [[package]]
 name = "anomaly"
 version = "0.2.0"
-source = "git+https://github.com/iqlusioninc/crates.git?branch=develop#c4f550fde01a0cceb707075d0b3c19464414c4c9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -315,7 +315,7 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "stdtx 0.1.0 (git+https://github.com/iqlusioninc/crates.git?branch=develop)",
+ "stdtx 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle-encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1524,10 +1524,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "stdtx"
-version = "0.1.0"
-source = "git+https://github.com/iqlusioninc/crates.git?branch=develop#c4f550fde01a0cceb707075d0b3c19464414c4c9"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "anomaly 0.2.0 (git+https://github.com/iqlusioninc/crates.git?branch=develop)",
+ "anomaly 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ecdsa 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-amino 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-amino-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1535,7 +1535,7 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle-encoding 0.5.1 (git+https://github.com/iqlusioninc/crates.git?branch=develop)",
+ "subtle-encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1549,14 +1549,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "subtle"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "subtle-encoding"
-version = "0.5.1"
-source = "git+https://github.com/iqlusioninc/crates.git?branch=develop#c4f550fde01a0cceb707075d0b3c19464414c4c9"
-dependencies = [
- "zeroize 1.1.0 (git+https://github.com/iqlusioninc/crates.git?branch=develop)",
-]
 
 [[package]]
 name = "subtle-encoding"
@@ -2100,11 +2092,6 @@ dependencies = [
 [[package]]
 name = "zeroize"
 version = "1.1.0"
-source = "git+https://github.com/iqlusioninc/crates.git?branch=develop#c4f550fde01a0cceb707075d0b3c19464414c4c9"
-
-[[package]]
-name = "zeroize"
-version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
@@ -2112,7 +2099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum abscissa_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "74f5722bc48763cb9d81d8427ca05b6aa2842f6632cf8e4c0a29eef9baececcc"
 "checksum abscissa_tokio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "50b7d1a5aa670b07be20e9457b491e78022d8421d4a39939f8b01a6a16ea85dc"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
-"checksum anomaly 0.2.0 (git+https://github.com/iqlusioninc/crates.git?branch=develop)" = "<none>"
+"checksum anomaly 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "550632e31568ae1a5f47998c3aa48563030fc49b9ec91913ca337cf64fbc5ccb"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9267dff192e68f3399525901e709a48c1d3982c9c072fa32f2127a0cb0babf14"
 "checksum arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
@@ -2285,10 +2272,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-"checksum stdtx 0.1.0 (git+https://github.com/iqlusioninc/crates.git?branch=develop)" = "<none>"
+"checksum stdtx 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "55a70ea828905d09be07f4a3fa64efb1993c673d7d5f6b2abf8d6cf29a21b2c0"
 "checksum strsim 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 "checksum subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
-"checksum subtle-encoding 0.5.1 (git+https://github.com/iqlusioninc/crates.git?branch=develop)" = "<none>"
 "checksum subtle-encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
@@ -2350,5 +2336,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-"checksum zeroize 1.1.0 (git+https://github.com/iqlusioninc/crates.git?branch=develop)" = "<none>"
 "checksum zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ once_cell = "1"
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 sha2 = "0.9"
-stdtx = "0.1"
+stdtx = "0.2"
 subtle-encoding = "0.5"
 thiserror = "1"
 tokio = "0.2"
@@ -33,6 +33,3 @@ warp = "0.2"
 
 [dev-dependencies]
 abscissa_core = { version = "0.5", features = ["testing"] }
-
-[patch.crates-io]
-stdtx = { git = "https://github.com/iqlusioninc/crates.git", branch = "develop" }

--- a/src/networks/terra/msg.rs
+++ b/src/networks/terra/msg.rs
@@ -43,8 +43,8 @@ impl MsgExchangeRateVote {
                 .decimal("exchange_rate", self.exchange_rate)?
                 .string("salt", &self.salt)?
                 .string("denom", self.denom.as_str())?
-                .acc_address("feeder", self.feeder.clone())?
-                .val_address("validator", self.validator.clone())?
+                .acc_address("feeder", self.feeder)?
+                .val_address("validator", self.validator)?
                 .to_msg(),
         )
     }
@@ -54,8 +54,8 @@ impl MsgExchangeRateVote {
         MsgExchangeRatePrevote {
             hash: self.generate_vote_hash(),
             denom: self.denom,
-            feeder: self.feeder.clone(),
-            validator: self.validator.clone(),
+            feeder: self.feeder,
+            validator: self.validator,
         }
     }
 
@@ -69,13 +69,9 @@ impl MsgExchangeRateVote {
             self.validator.to_bech32("terravaloper"),
         );
 
-        // Tendermint truncated sha256
+        // Tendermint truncated SHA-256
         let digest = Sha256::digest(data.as_bytes());
-        let mut bytes = [0u8; 20];
-        bytes.copy_from_slice(&digest[..20]);
-
-        // Should always succeed.
-        String::from_utf8(hex::encode(bytes)).unwrap()
+        String::from_utf8(hex::encode(&digest[..20])).unwrap()
     }
 }
 
@@ -104,8 +100,8 @@ impl MsgExchangeRatePrevote {
             stdtx::msg::Builder::new(&SCHEMA, "oracle/MsgExchangeRatePrevote")?
                 .string("hash", &self.hash)?
                 .string("denom", self.denom.as_str())?
-                .acc_address("feeder", self.feeder.clone())?
-                .val_address("validator", self.validator.clone())?
+                .acc_address("feeder", self.feeder)?
+                .val_address("validator", self.validator)?
                 .to_msg(),
         )
     }


### PR DESCRIPTION
It's not presently supported:

https://terra.stake.id/?#/tx/C3E0F47AB3472B5893EF1A1CD51D08842CAF4CFD4E918C4980129E2D5CD40C5F

A new `AggregatePriceVote` message will be added in `columbus-4` which will allow for this batching. For now we just need to send a bunch of separate transactions like we were doing before.