### PR TITLE
Currency, Price, TradingPair refactor

### DIFF
--- a/src/currency.rs
+++ b/src/currency.rs
@@ -1,0 +1,113 @@
+//! Currency support (i.e. assets)
+
+use crate::Error;
+use serde::{de, ser, Deserialize, Serialize};
+use std::{
+    fmt::{self, Display},
+    str::FromStr,
+};
+
+/// Currencies for use in trading pairs
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum Currency {
+    /// Cosmos Atom
+    Atom,
+
+    /// Binance Coin
+    Bnb,
+
+    /// Binance KRW (won) stablecoin
+    Bkrw,
+
+    /// Bitcoin
+    Btc,
+
+    /// Binance USD stablecoin
+    Busd,
+
+    /// Ethereum
+    Eth,
+
+    /// Euro
+    Eur,
+
+    /// UK Pounds
+    Gbp,
+
+    /// South Korean won
+    Krw,
+
+    /// Terra Luna
+    Luna,
+
+    /// US dollars
+    Usd,
+
+    /// Circle stablecoin
+    Usdc,
+
+    /// Tether USDT stablecoin
+    Usdt,
+
+    /// Other (open-ended)
+    Other(String),
+}
+
+impl Display for Currency {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Currency::Atom => "ATOM",
+            Currency::Bnb => "BNB",
+            Currency::Bkrw => "BKRW",
+            Currency::Btc => "BTC",
+            Currency::Busd => "BUSD",
+            Currency::Eth => "ETH",
+            Currency::Eur => "EUR",
+            Currency::Gbp => "GBP",
+            Currency::Krw => "KRW",
+            Currency::Luna => "LUNA",
+            Currency::Usd => "USD",
+            Currency::Usdc => "USDC",
+            Currency::Usdt => "USDT",
+            Currency::Other(other) => other.as_ref(),
+        })
+    }
+}
+
+impl FromStr for Currency {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        Ok(match s.to_ascii_uppercase().as_ref() {
+            "ATOM" => Currency::Atom,
+            "BNB" => Currency::Bnb,
+            "BKRW" => Currency::Bkrw,
+            "BTC" => Currency::Btc,
+            "BUSD" => Currency::Busd,
+            "ETH" => Currency::Eth,
+            "EUR" => Currency::Eur,
+            "GBP" => Currency::Gbp,
+            "KRW" => Currency::Krw,
+            "LUNA" => Currency::Luna,
+            "USD" => Currency::Usd,
+            "USDC" => Currency::Usdc,
+            "USDT" => Currency::Usdt,
+            other => Currency::Other(other.to_owned()),
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for Currency {
+    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use de::Error;
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(D::Error::custom)
+    }
+}
+
+impl Serialize for Currency {
+    fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.to_string().serialize(serializer)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,17 @@
 pub mod application;
 pub mod commands;
 pub mod config;
+pub mod currency;
 pub mod error;
 pub mod networks;
 pub mod prelude;
+pub mod price;
 pub mod sources;
+pub mod trading_pair;
+
+pub use self::{
+    currency::Currency,
+    error::{Error, ErrorKind},
+    price::{Price, PriceQuantity},
+    trading_pair::TradingPair,
+};

--- a/src/price.rs
+++ b/src/price.rs
@@ -1,0 +1,152 @@
+//! Prices (wrapper for `Decimal`)
+
+use crate::{prelude::*, Error, ErrorKind};
+use rust_decimal::{prelude::*, Decimal};
+use serde::{de, ser, Deserialize, Serialize};
+use std::{
+    cmp::Ordering,
+    convert::TryFrom,
+    fmt::{self, Display},
+    ops::{Add, Deref, Div, Mul},
+    str::FromStr,
+};
+
+/// Prices of currencies (internally represented as a `Decimal`)
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct Price(Decimal);
+
+impl Price {
+    /// Create a new price from a `Decimal`
+    pub(crate) fn new(decimal: Decimal) -> Result<Self, Error> {
+        if decimal.to_f32().is_none() || decimal.to_f64().is_none() {
+            fail!(ErrorKind::Parse, "price cannot be represented as float");
+        }
+
+        Ok(Price(decimal))
+    }
+}
+
+impl Add for Price {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        Self(self.0 + rhs.0)
+    }
+}
+
+impl Mul for Price {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self {
+        Self(self.0 * rhs.0)
+    }
+}
+
+impl Mul<Decimal> for Price {
+    type Output = Self;
+
+    fn mul(self, rhs: Decimal) -> Self {
+        Self(self.0 * rhs)
+    }
+}
+
+impl Div<Decimal> for Price {
+    type Output = Self;
+
+    fn div(self, rhs: Decimal) -> Price {
+        Self(self.0 / rhs)
+    }
+}
+
+impl Div<u64> for Price {
+    type Output = Self;
+
+    fn div(self, rhs: u64) -> Price {
+        self / Decimal::from(rhs)
+    }
+}
+
+impl Deref for Price {
+    type Target = Decimal;
+
+    fn deref(&self) -> &Decimal {
+        &self.0
+    }
+}
+
+impl Display for Price {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl FromStr for Price {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        Self::new(s.parse()?)
+    }
+}
+
+impl<'de> Deserialize<'de> for Price {
+    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use de::Error;
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(D::Error::custom)
+    }
+}
+
+impl Serialize for Price {
+    fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.to_string().serialize(serializer)
+    }
+}
+
+impl TryFrom<Decimal> for Price {
+    type Error = Error;
+
+    fn try_from(decimal: Decimal) -> Result<Price, Error> {
+        Price::new(decimal)
+    }
+}
+
+impl From<Price> for Decimal {
+    fn from(price: Price) -> Decimal {
+        price.0
+    }
+}
+
+impl From<&Price> for Decimal {
+    fn from(price: &Price) -> Decimal {
+        price.0
+    }
+}
+
+/// Quoted prices and quantities as sourced from the order book
+#[derive(Clone, Debug, Eq)]
+pub struct PriceQuantity {
+    /// Price
+    pub price: Price,
+
+    /// Quantity
+    pub quantity: Decimal,
+}
+
+impl Ord for PriceQuantity {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.price.cmp(&other.price)
+    }
+}
+
+impl PartialOrd for PriceQuantity {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for PriceQuantity {
+    fn eq(&self, other: &Self) -> bool {
+        self.price == other.price
+    }
+}

--- a/src/sources/alphavantage.rs
+++ b/src/sources/alphavantage.rs
@@ -2,8 +2,8 @@
 //! <https://www.alphavantage.co/>
 //!
 
-use super::{Pair, Price, USER_AGENT};
-use crate::error::Error;
+use super::USER_AGENT;
+use crate::{Error, Price, TradingPair};
 use bytes::buf::ext::BufExt;
 use hyper::{
     client::{Client, HttpConnector},
@@ -65,7 +65,7 @@ impl AlphavantageSource {
     }
 
     /// Get trading pairs
-    pub async fn trading_pairs(&self, pair: &Pair) -> Result<Response, Error> {
+    pub async fn trading_pairs(&self, pair: &TradingPair) -> Result<Response, Error> {
         let params = AlphavantageParams {
             function: "CURRENCY_EXCHANGE_RATE".to_owned(),
             from_currency: pair.0.to_string(),

--- a/src/sources/coinone.rs
+++ b/src/sources/coinone.rs
@@ -3,11 +3,8 @@
 //!
 //! Only KRW pairs are supported.
 
-use super::{AskBook, BidBook, Currency, Pair, Price, PriceQuantity, USER_AGENT};
-use crate::{
-    error::{Error, ErrorKind},
-    prelude::*,
-};
+use super::{AskBook, BidBook, USER_AGENT};
+use crate::{prelude::*, Currency, Error, ErrorKind, Price, PriceQuantity, TradingPair};
 use bytes::buf::ext::BufExt;
 use hyper::{
     client::{Client, HttpConnector},
@@ -34,7 +31,7 @@ impl CoinoneSource {
     }
 
     /// Get trading pairs
-    pub async fn trading_pairs(&self, pair: &Pair) -> Result<Response, Error> {
+    pub async fn trading_pairs(&self, pair: &TradingPair) -> Result<Response, Error> {
         if pair.1 != Currency::Krw {
             fail!(ErrorKind::Currency, "trading pair must be with KRW");
         }
@@ -95,7 +92,7 @@ impl AskBook for Response {
                 p.qty
                     .parse()
                     .map(|quantity| PriceQuantity {
-                        price: p.price.clone(),
+                        price: p.price,
                         quantity,
                     })
                     .map_err(Into::into)
@@ -113,7 +110,7 @@ impl BidBook for Response {
                 p.qty
                     .parse()
                     .map(|quantity| PriceQuantity {
-                        price: p.price.clone(),
+                        price: p.price,
                         quantity,
                     })
                     .map_err(Into::into)

--- a/src/sources/gdac.rs
+++ b/src/sources/gdac.rs
@@ -1,11 +1,8 @@
 //! GDAC Source Provider (v0.4 API)
 //! <https://www.gdac.com/>
 
-use super::{AskBook, BidBook, Pair, Price, PriceQuantity};
-use crate::{
-    error::{Error, ErrorKind},
-    prelude::*,
-};
+use super::{AskBook, BidBook};
+use crate::{prelude::*, Error, ErrorKind, Price, PriceQuantity, TradingPair};
 use bytes::buf::ext::BufExt;
 use hyper::{
     client::{Client, HttpConnector},
@@ -39,7 +36,7 @@ impl GdacSource {
     }
 
     /// Get trading pairs
-    pub async fn trading_pairs(&self, pair: &Pair) -> Result<Quote, Error> {
+    pub async fn trading_pairs(&self, pair: &TradingPair) -> Result<Quote, Error> {
         let uri = format!(
             "{}/public/orderbook?pair={}",
             BASE_URI_V4,
@@ -104,7 +101,7 @@ impl AskBook for Quote {
                 p.volume
                     .parse()
                     .map(|quantity| PriceQuantity {
-                        price: p.price.clone(),
+                        price: p.price,
                         quantity,
                     })
                     .map_err(Into::into)
@@ -122,7 +119,7 @@ impl BidBook for Quote {
                 p.volume
                     .parse()
                     .map(|quantity| PriceQuantity {
-                        price: p.price.clone(),
+                        price: p.price,
                         quantity,
                     })
                     .map_err(Into::into)

--- a/src/sources/gopax.rs
+++ b/src/sources/gopax.rs
@@ -2,11 +2,8 @@
 //! <https://www.gopax.co.id/API/>
 //! <https://api.gopax.co.kr/trading-pairs/LUNA-KRW/book>
 
-use super::{AskBook, BidBook, Pair, Price, PriceQuantity, USER_AGENT};
-use crate::{
-    error::{Error, ErrorKind},
-    prelude::*,
-};
+use super::{AskBook, BidBook, USER_AGENT};
+use crate::{prelude::*, Error, ErrorKind, Price, PriceQuantity, TradingPair};
 use bytes::buf::ext::BufExt;
 use hyper::{
     client::{Client, HttpConnector},
@@ -35,7 +32,7 @@ impl GopaxSource {
     }
 
     /// Get trading pairs
-    pub async fn trading_pairs(&self, pair: &Pair) -> Result<Response, Error> {
+    pub async fn trading_pairs(&self, pair: &TradingPair) -> Result<Response, Error> {
         let uri = format!("{}/trading-pairs/{}-{}/book", BASE_URI, pair.0, pair.1);
         dbg!(&uri);
 

--- a/src/trading_pair.rs
+++ b/src/trading_pair.rs
@@ -1,0 +1,54 @@
+//! Trading pairs
+
+use crate::{prelude::*, Currency, Error, ErrorKind};
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+use serde::{de, ser, Deserialize, Serialize};
+use std::{
+    fmt::{self, Display},
+    str::FromStr,
+};
+
+/// Trading pairs
+pub struct TradingPair(pub Currency, pub Currency);
+
+impl TradingPair {
+    /// Percent encode this pair (for inclusion in a URL)
+    pub fn percent_encode(&self) -> String {
+        utf8_percent_encode(&self.to_string(), NON_ALPHANUMERIC).to_string()
+    }
+}
+
+impl Display for TradingPair {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.0, self.1)
+    }
+}
+
+impl FromStr for TradingPair {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        let pair: Vec<_> = s.split('/').collect();
+
+        if pair.len() != 2 {
+            fail!(ErrorKind::Parse, "malformed trading pair: {}", s);
+        }
+
+        Ok(TradingPair(pair[0].parse()?, pair[1].parse()?))
+    }
+}
+
+impl<'de> Deserialize<'de> for TradingPair {
+    fn deserialize<D: de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use de::Error;
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(D::Error::custom)
+    }
+}
+
+impl Serialize for TradingPair {
+    fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.to_string().serialize(serializer)
+    }
+}


### PR DESCRIPTION
- Extracts `Currency` into the `delphi::currency` module
- Extracts `Price` and `PriceQuantity` into the `delphi::price` module
- Renames `Pair` => `TradingPair`; extracts into `delphi::trading_pair`
- `Price` improvements:
  - Makes inner `Decimal` non-pub so constructor can maintain invariant
  - Adds `Add`, `Mul`, and `Div` impls so we can do math on `Price`
  - Adds a `Deref` impl as a way to get to the inner `Decimal `easily
  - Adds `From` and `TryInto` impls for `Decimal`
  - Impls `Copy` on `Price` (inner `Decimal` is `Copy` so why not)
- Updates Binance source to return `Price`