### PR TITLE
terra: aggregate votes

### DIFF
--- a/src/networks/terra/denom.rs
+++ b/src/networks/terra/denom.rs
@@ -17,7 +17,7 @@ use std::{
 };
 
 /// Denomination
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub enum Denom {
     /// Korean Wan
     UKRW,

--- a/src/networks/terra/msg.rs
+++ b/src/networks/terra/msg.rs
@@ -3,25 +3,28 @@
 // TODO(tarcieri): autogenerate this from the schema? (possibly after proto migration)
 
 use super::{Denom, SCHEMA};
-use crate::error::Error;
+use crate::{
+    error::{Error, ErrorKind},
+    prelude::*,
+};
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use sha2::{Digest, Sha256};
+use std::{
+    collections::BTreeMap as Map,
+    fmt::{self, Display},
+};
 use stdtx::{Address, Decimal};
 use subtle_encoding::hex;
 
-/// Terra Oracle Vote Message (`oracle/MsgExchangeRateVote`)
-///
-/// <https://docs.terra.money/dev/spec-oracle.html#msgexchangeratevote>
+/// Terra Oracle Aggregate Vote Message (`oracle/MsgAggregateExchangeRateVote`)
+/// <https://docs.terra.money/dev/spec-oracle.html#msgaggregateexchangeratevote>
 #[derive(Clone, Debug)]
-pub struct MsgExchangeRateVote {
-    /// Exchange rate voted on. Negative values are an abstain vote.
-    pub exchange_rate: Decimal,
+pub struct MsgAggregateExchangeRateVote {
+    /// Exchange rates to be voted on. Negative values are an abstain vote.
+    pub exchange_rates: ExchangeRates,
 
     /// Salt for commit reveal protocol
     pub salt: String,
-
-    /// Denom for Oracle Vote
-    pub denom: Denom,
 
     /// Origin of the Feed Msg
     pub feeder: Address,
@@ -30,19 +33,18 @@ pub struct MsgExchangeRateVote {
     pub validator: Address,
 }
 
-impl MsgExchangeRateVote {
+impl MsgAggregateExchangeRateVote {
     /// Get a random salt value
     pub fn random_salt() -> String {
         thread_rng().sample_iter(&Alphanumeric).take(4).collect()
     }
 
-    /// Simple builder for an `oracle/MsgExchangeRateVote` message
+    /// Simple builder for an `oracle/MsgAggregateExchangeRateVote` message
     pub fn to_stdtx_msg(&self) -> Result<stdtx::Msg, Error> {
         Ok(
-            stdtx::msg::Builder::new(&SCHEMA, "oracle/MsgExchangeRateVote")?
-                .decimal("exchange_rate", self.exchange_rate)?
+            stdtx::msg::Builder::new(&SCHEMA, "oracle/MsgAggregateExchangeRateVote")?
+                .string("exchange_rates", self.exchange_rates.to_string())?
                 .string("salt", &self.salt)?
-                .string("denom", self.denom.as_str())?
                 .acc_address("feeder", self.feeder)?
                 .val_address("validator", self.validator)?
                 .to_msg(),
@@ -50,10 +52,9 @@ impl MsgExchangeRateVote {
     }
 
     /// Compute prevote from this vote
-    pub fn prevote(&self) -> MsgExchangeRatePrevote {
-        MsgExchangeRatePrevote {
+    pub fn prevote(&self) -> MsgAggregateExchangeRatePrevote {
+        MsgAggregateExchangeRatePrevote {
             hash: self.generate_vote_hash(),
-            denom: self.denom,
             feeder: self.feeder,
             validator: self.validator,
         }
@@ -62,10 +63,9 @@ impl MsgExchangeRateVote {
     /// Generate hex encoded truncated SHA-256 of vote. Needed to generate prevote
     fn generate_vote_hash(&self) -> String {
         let data = format!(
-            "{}:{}:{}:{}",
+            "{}:{}:{}",
             self.salt,
-            self.exchange_rate,
-            self.denom.as_str(),
+            self.exchange_rates.to_string(),
             self.validator.to_bech32("terravaloper"),
         );
 
@@ -79,16 +79,12 @@ impl MsgExchangeRateVote {
     }
 }
 
-/// Terra Oracle Prevote Message (`oracle/MsgExchangeRatePrevote`)
-///
-/// <https://docs.terra.money/dev/spec-oracle.html#msgexchangerateprevote>
+/// Terra Oracle Aggregate Prevote Message (`oracle/MsgAggregateExchangeRatePrevote`)
+/// <https://docs.terra.money/dev/spec-oracle.html#msgaggregateexchangerateprevote>
 #[derive(Clone, Debug)]
-pub struct MsgExchangeRatePrevote {
+pub struct MsgAggregateExchangeRatePrevote {
     /// Commitment to future vote
     pub hash: String,
-
-    /// Denom to commit for
-    pub denom: Denom,
 
     /// Origin Address for vote
     pub feeder: Address,
@@ -97,16 +93,98 @@ pub struct MsgExchangeRatePrevote {
     pub validator: Address,
 }
 
-impl MsgExchangeRatePrevote {
-    /// Simple builder for an `oracle/MsgExchangeRatePrevote` message
+impl MsgAggregateExchangeRatePrevote {
+    /// Simple builder for an `oracle/MsgAggregateExchangeRatePrevote` message
     pub fn to_stdtx_msg(&self) -> Result<stdtx::Msg, Error> {
         Ok(
-            stdtx::msg::Builder::new(&SCHEMA, "oracle/MsgExchangeRatePrevote")?
+            stdtx::msg::Builder::new(&SCHEMA, "oracle/MsgAggregateExchangeRatePrevote")?
                 .string("hash", &self.hash)?
-                .string("denom", self.denom.as_str())?
                 .acc_address("feeder", self.feeder)?
                 .val_address("validator", self.validator)?
                 .to_msg(),
         )
+    }
+}
+
+/// Exchange rates
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ExchangeRates(Map<Denom, Decimal>);
+
+impl ExchangeRates {
+    /// Create a new set of exchange rates
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a new set of exchange rates from an iterator over
+    /// `(Denom,Decimal)` tuples
+    // NOTE: can't use `FromIterator` here because of the `Result`
+    pub fn from_exchange_rates<'a, I>(iter: I) -> Result<Self, Error>
+    where
+        I: Iterator<Item = &'a (Denom, Decimal)>,
+    {
+        let mut exchange_rates = ExchangeRates::new();
+
+        for &(denom, rate) in iter {
+            exchange_rates.add(denom, rate)?;
+        }
+
+        Ok(exchange_rates)
+    }
+
+    /// Add an exchange rate
+    pub fn add(&mut self, denom: Denom, rate: Decimal) -> Result<(), Error> {
+        let duplicate = self.0.insert(denom, rate).is_some();
+
+        ensure!(
+            !duplicate,
+            ErrorKind::Currency,
+            "duplicate exchange rate for denom: {}",
+            denom
+        );
+
+        Ok(())
+    }
+}
+
+impl Display for ExchangeRates {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (i, (denom, rate)) in self.0.iter().enumerate() {
+            write!(f, "{}{}", rate, denom)?;
+
+            if i < self.0.len() - 1 {
+                write!(f, ",")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Denom, ExchangeRates};
+
+    #[test]
+    fn exchange_rate_to_string() {
+        let exchange_rates = ExchangeRates::from_exchange_rates(
+            [
+                (Denom::UUSD, "1".parse().unwrap()),
+                (Denom::USDR, "1".parse().unwrap()),
+                (Denom::UMNT, "888".parse().unwrap()),
+                (Denom::UKRW, "362".parse().unwrap()),
+            ]
+            .iter(),
+        )
+        .unwrap();
+
+        let serialized_rates = exchange_rates.to_string();
+        assert_eq!(
+            &serialized_rates,
+            "362.000000000000000000ukrw,\
+            888.000000000000000000umnt,\
+            1.000000000000000000usdr,\
+            1.000000000000000000uusd"
+        );
     }
 }

--- a/src/networks/terra/schema.toml
+++ b/src/networks/terra/schema.toml
@@ -10,6 +10,29 @@ val_prefix = "terravaloper"
 # <https://docs.terra.money/dev/spec-oracle.html>
 #
 
+# MsgAggregateExchangeRatePrevote
+# (NOTE: presently undocumented. See example below)
+# <https://finder.terra.money/columbus-4/tx/6E2E83CF8B2F287CDBFD6C3716A65F6D3235EAEF233198289688B2A65609A71A>
+[[definition]]
+type_name = "oracle/MsgAggregateExchangeRatePrevote"
+fields = [
+    { name = "hash",  type = "string" },
+    { name = "feeder", type = "sdk.AccAddress" },
+    { name = "validator", type = "sdk.ValAddress" },
+]
+
+# MsgAggregateExchangeRateVote
+# (NOTE: presently undocumented. See example below)
+# <https://finder.terra.money/columbus-4/tx/6E2E83CF8B2F287CDBFD6C3716A65F6D3235EAEF233198289688B2A65609A71A>
+[[definition]]
+type_name = "oracle/MsgAggregateExchangeRateVote"
+fields = [
+    { name = "exchange_rates", type = "string"},
+    { name = "salt", type = "string" },
+    { name = "feeder", type = "sdk.AccAddress" },
+    { name = "validator", type = "sdk.ValAddress" },
+]
+
 # MsgExchangeRatePrevote
 # <https://docs.terra.money/dev/spec-oracle.html#msgexchangerateprevote>
 [[definition]]


### PR DESCRIPTION
Impls the new aggregate vote messages for `columbus-4`:

- `MsgAggregateExchangeRateVote`
- `MsgAggregateExchangeRatePrevote`

These vote message types reduce the total number of messages required to express an oracle vote.