### PR TITLE
terra: fix MsgAggregateExchangeRateVote field ordering

### DIFF
--- a/src/networks/terra/schema.toml
+++ b/src/networks/terra/schema.toml
@@ -27,8 +27,8 @@ fields = [
 [[definition]]
 type_name = "oracle/MsgAggregateExchangeRateVote"
 fields = [
-    { name = "exchange_rates", type = "string"},
     { name = "salt", type = "string" },
+    { name = "exchange_rates", type = "string"},
     { name = "feeder", type = "sdk.AccAddress" },
     { name = "validator", type = "sdk.ValAddress" },
 ]


### PR DESCRIPTION
Matches the field ordering here:

https://github.com/terra-project/core/blob/v0.4.0/x/oracle/internal/types/msgs.go#L284-L289