### PR TITLE
terra: add oracle state initializer

### DIFF
--- a/delphi.example.toml
+++ b/delphi.example.toml
@@ -1,7 +1,0 @@
-# Example Delphi configuration file
-
-[network.terra]
-chain_id = "columbus-4"
-
-[source]
-alphavantage = {apikey = "api key goes here"}

--- a/delphi.toml.example
+++ b/delphi.toml.example
@@ -1,0 +1,10 @@
+# Example Delphi configuration file
+
+[network.terra]
+chain_id = "columbus-4"
+feeder = "terra1..."
+validator = "terravaloper1..."
+
+[source.alphavantage]
+# Get API key here (quick-and-simple form): https://www.alphavantage.co/support/#api-key
+apikey = "api key goes here"

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -5,12 +5,6 @@ use abscissa_core::{prelude::*, Command, Options, Runnable};
 use std::process;
 use warp::Filter;
 
-/// Feeder address
-pub const FEEDER_ADDR: &str = "terra1t9et8wjeh8d0ewf4lldchterxsmhpcgg5auy47";
-
-/// Validator address
-pub const VALIDATOR_ADDR: &str = "terravaloper1grgelyng2v6v3t8z87wu3sxgt9m5s03x2mfyu7";
-
 /// `start` subcommand
 #[derive(Command, Debug, Options)]
 pub struct StartCmd {}
@@ -23,11 +17,7 @@ impl Runnable for StartCmd {
             let listen_addr = [127, 0, 0, 1];
             let listen_port = 23456;
 
-            // TODO(tarcieri): load feeder/validator from config file
-            let feeder = stdtx::Address::from_bech32(FEEDER_ADDR).unwrap().1;
-            let validator = stdtx::Address::from_bech32(VALIDATOR_ADDR).unwrap().1;
-
-            let terra_oracle = terra::ExchangeRateOracle::new(feeder, validator);
+            let terra_oracle = terra::ExchangeRateOracle::new();
             let terra_oracle_filter = warp::any().map(move || terra_oracle.clone());
 
             let app = warp::post()

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,12 @@ pub struct NetworkConfig {
 pub struct TerraConfig {
     /// Terra chain id
     pub chain_id: String,
+
+    /// Feeder address (Bech32)
+    pub feeder: String,
+
+    /// Validator address (Bech32)
+    pub validator: String,
 }
 
 /// Source Configuration


### PR DESCRIPTION
Factors all Terra oracle state initialization (i.e. configuration processing) into `terra::OracleState::new`.