### PR TITLE
terra: split oracle prevote/vote into two transactions

### DIFF
--- a/src/networks/terra/msg.rs
+++ b/src/networks/terra/msg.rs
@@ -19,6 +19,12 @@ use stdtx::{Address, Decimal};
 /// Truncated SHA-256 hash to include in a pre-vote
 pub type Hash = [u8; 20];
 
+/// Message type name for [`MsgAggregateExchangeRateVote`]
+pub const VOTE_MSG_NAME: &str = "oracle/MsgAggregateExchangeRateVote";
+
+/// Message type name for [`MsgAggregateExchangeRatePrevote`]
+pub const PREVOTE_MSG_NAME: &str = "oracle/MsgAggregateExchangeRatePrevote";
+
 /// Terra Oracle Aggregate Vote Message (`oracle/MsgAggregateExchangeRateVote`)
 /// <https://docs.terra.money/dev/spec-oracle.html#msgaggregateexchangeratevote>
 #[derive(Clone, Debug)]
@@ -44,14 +50,12 @@ impl MsgAggregateExchangeRateVote {
 
     /// Simple builder for an `oracle/MsgAggregateExchangeRateVote` message
     pub fn to_stdtx_msg(&self) -> Result<stdtx::Msg, Error> {
-        Ok(
-            stdtx::msg::Builder::new(&SCHEMA, "oracle/MsgAggregateExchangeRateVote")?
-                .string("exchange_rates", self.exchange_rates.to_string())?
-                .string("salt", &self.salt)?
-                .acc_address("feeder", self.feeder)?
-                .val_address("validator", self.validator)?
-                .to_msg(),
-        )
+        Ok(stdtx::msg::Builder::new(&SCHEMA, VOTE_MSG_NAME)?
+            .string("exchange_rates", self.exchange_rates.to_string())?
+            .string("salt", &self.salt)?
+            .acc_address("feeder", self.feeder)?
+            .val_address("validator", self.validator)?
+            .to_msg())
     }
 
     /// Compute prevote from this vote
@@ -95,13 +99,11 @@ pub struct MsgAggregateExchangeRatePrevote {
 impl MsgAggregateExchangeRatePrevote {
     /// Simple builder for an `oracle/MsgAggregateExchangeRatePrevote` message
     pub fn to_stdtx_msg(&self) -> Result<stdtx::Msg, Error> {
-        Ok(
-            stdtx::msg::Builder::new(&SCHEMA, "oracle/MsgAggregateExchangeRatePrevote")?
-                .bytes("hash", self.hash.as_ref())?
-                .acc_address("feeder", self.feeder)?
-                .val_address("validator", self.validator)?
-                .to_msg(),
-        )
+        Ok(stdtx::msg::Builder::new(&SCHEMA, PREVOTE_MSG_NAME)?
+            .bytes("hash", self.hash.as_ref())?
+            .acc_address("feeder", self.feeder)?
+            .val_address("validator", self.validator)?
+            .to_msg())
     }
 }
 


### PR DESCRIPTION
We're encountering cases where we miss the reveal period for a vote because it's too long after a prevote:

https://finder.terra.money/columbus-4/tx/CA9A739E252F36F1300CC094B5C13C095EC431F59C3E41B0390CFCE70FE43F17

```
no aggregate prevote: terravaloper1grgelyng2v6v3t8z87wu3sxgt9m5s03x2mfyu7: failed to execute message; message index: 0
```

This, unfortunately, breaks the prevote contained in the same transaction, and thus all subsequent votes.

As a bit of a workaround, we can split the vote and next prevote into two different transactions, which means a failing vote won't block the next prevote.

It appears we only need to pay a fee on votes, not prevotes, and the fee calculation logic reflects that.