### PR TITLE
Revert "terra: split oracle prevote/vote into two transactions (#71)"

### DIFF
--- a/src/networks/terra/msg.rs
+++ b/src/networks/terra/msg.rs
@@ -19,12 +19,6 @@ use stdtx::{Address, Decimal};
 /// Truncated SHA-256 hash to include in a pre-vote
 pub type Hash = [u8; 20];
 
-/// Message type name for [`MsgAggregateExchangeRateVote`]
-pub const VOTE_MSG_NAME: &str = "oracle/MsgAggregateExchangeRateVote";
-
-/// Message type name for [`MsgAggregateExchangeRatePrevote`]
-pub const PREVOTE_MSG_NAME: &str = "oracle/MsgAggregateExchangeRatePrevote";
-
 /// Terra Oracle Aggregate Vote Message (`oracle/MsgAggregateExchangeRateVote`)
 /// <https://docs.terra.money/dev/spec-oracle.html#msgaggregateexchangeratevote>
 #[derive(Clone, Debug)]
@@ -50,12 +44,14 @@ impl MsgAggregateExchangeRateVote {
 
     /// Simple builder for an `oracle/MsgAggregateExchangeRateVote` message
     pub fn to_stdtx_msg(&self) -> Result<stdtx::Msg, Error> {
-        Ok(stdtx::msg::Builder::new(&SCHEMA, VOTE_MSG_NAME)?
-            .string("exchange_rates", self.exchange_rates.to_string())?
-            .string("salt", &self.salt)?
-            .acc_address("feeder", self.feeder)?
-            .val_address("validator", self.validator)?
-            .to_msg())
+        Ok(
+            stdtx::msg::Builder::new(&SCHEMA, "oracle/MsgAggregateExchangeRateVote")?
+                .string("exchange_rates", self.exchange_rates.to_string())?
+                .string("salt", &self.salt)?
+                .acc_address("feeder", self.feeder)?
+                .val_address("validator", self.validator)?
+                .to_msg(),
+        )
     }
 
     /// Compute prevote from this vote
@@ -99,11 +95,13 @@ pub struct MsgAggregateExchangeRatePrevote {
 impl MsgAggregateExchangeRatePrevote {
     /// Simple builder for an `oracle/MsgAggregateExchangeRatePrevote` message
     pub fn to_stdtx_msg(&self) -> Result<stdtx::Msg, Error> {
-        Ok(stdtx::msg::Builder::new(&SCHEMA, PREVOTE_MSG_NAME)?
-            .bytes("hash", self.hash.as_ref())?
-            .acc_address("feeder", self.feeder)?
-            .val_address("validator", self.validator)?
-            .to_msg())
+        Ok(
+            stdtx::msg::Builder::new(&SCHEMA, "oracle/MsgAggregateExchangeRatePrevote")?
+                .bytes("hash", self.hash.as_ref())?
+                .acc_address("feeder", self.feeder)?
+                .val_address("validator", self.validator)?
+                .to_msg(),
+        )
     }
 }
 

--- a/src/networks/terra/oracle.rs
+++ b/src/networks/terra/oracle.rs
@@ -2,14 +2,14 @@
 
 use super::{
     denom::Denom,
-    msg::{self, MsgAggregateExchangeRateVote, VOTE_MSG_NAME},
+    msg::{self, MsgAggregateExchangeRateVote},
     MEMO, SCHEMA,
 };
 use crate::{application::app_config, config::DelphiConfig, prelude::*, sources::Sources, Error};
 use futures::future::join_all;
 use serde_json::json;
 use std::{convert::Infallible, sync::Arc, time::Instant};
-use stdtx::{amino_types::StdFee, Address, TypeName};
+use stdtx::{amino_types::StdFee, Address};
 use tokio::sync::Mutex;
 use warp::http::StatusCode;
 
@@ -43,23 +43,22 @@ impl ExchangeRateOracle {
         let started_at = Instant::now();
         let chain_id = self.get_chain_id().await;
         let msgs = self.get_vote_msgs().await;
-        let oracle_state = self.0.lock().await;
 
-        let tx = msgs
+        let msg_json = msgs
             .iter()
-            .map(|msg| {
-                json!({
-                    "chain_id": chain_id,
-                    "fee": oracle_state.fee(msg.type_name()),
-                    "memo": MEMO,
-                    "msgs": [msg.to_json_value(&SCHEMA)],
-                })
-            })
+            .map(|msg| msg.to_json_value(&SCHEMA))
             .collect::<Vec<_>>();
+
+        let tx = json!({
+            "chain_id": chain_id,
+            "fee": self.oracle_fee().await,
+            "memo": MEMO,
+            "msgs": msg_json,
+        });
 
         let response = json!({
             "status": "ok",
-            "tx": tx
+            "tx": vec![tx]
         });
 
         info!("t={:?}", Instant::now().duration_since(started_at));
@@ -125,6 +124,12 @@ impl ExchangeRateOracle {
 
         msgs
     }
+
+    /// Compute the oracle fee
+    pub async fn oracle_fee(&self) -> StdFee {
+        let state = self.0.lock().await;
+        state.fee.clone()
+    }
 }
 
 impl Default for ExchangeRateOracle {
@@ -182,14 +187,5 @@ impl OracleState {
             sources,
             unrevealed_votes: vec![],
         })
-    }
-
-    /// Compute the oracle fee
-    pub fn fee(&self, msg_type: &TypeName) -> StdFee {
-        if msg_type.as_str() == VOTE_MSG_NAME {
-            self.fee.clone()
-        } else {
-            StdFee::for_gas(self.fee.gas)
-        }
     }
 }


### PR DESCRIPTION
This reverts commit 672a85ce8d1569f7bfa10e189d7f389c117b1de3.

Unfortunately this increases the amount of time required to broadcast transactions which puts us outside the voting period.

We can't really fix that problem until we can query the sequence number, as it would break local sequence number persistence.

Until we can do that, we need to look at alternatives to solving this problem.