### PR TITLE
Remove `dbg!` statements; add logging

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,3 +22,5 @@ pub use self::{
     price::{Price, PriceQuantity},
     trading_pair::TradingPair,
 };
+
+pub use std::collections::{btree_map as map, BTreeMap as Map};

--- a/src/networks/terra/denom.rs
+++ b/src/networks/terra/denom.rs
@@ -60,16 +60,11 @@ impl Denom {
                     sources.binance.approx_price_for_pair(&pair)
                 )?;
 
-                dbg!(&coinone_midpoint, &gdac_midpoint, &binance_response);
-
                 //Midpoint avg for all sources
                 let mut luna_krw =
                     Decimal::from((coinone_midpoint + gdac_midpoint + binance_response) / 3);
-                dbg!(&luna_krw);
 
-                dbg!(&luna_krw, luna_krw.scale());
                 luna_krw.rescale(18);
-                dbg!(&luna_krw, luna_krw.scale());
                 Ok(luna_krw.try_into()?)
             }
 
@@ -99,10 +94,8 @@ impl Denom {
                         + coinone_midpoint * alphavantage_response_krw)
                         / 2,
                 );
-                dbg!(luna_mnt);
 
                 luna_mnt.rescale(18);
-
                 Ok(luna_mnt.try_into()?)
             }
 
@@ -113,11 +106,7 @@ impl Denom {
                     .await?;
 
                 let mut luna_usd: Decimal = binance_response.into();
-
-                dbg!(luna_usd);
-
                 luna_usd.rescale(18);
-
                 Ok(luna_usd.try_into()?)
             }
 
@@ -132,11 +121,7 @@ impl Denom {
                 )?;
 
                 let mut luna_sdr = Decimal::from(coinone_midpoint * imf_sdr_response.price);
-
-                dbg!(luna_sdr);
-
                 luna_sdr.rescale(18);
-
                 Ok(luna_sdr.try_into()?)
             }
         }

--- a/src/networks/terra/msg.rs
+++ b/src/networks/terra/msg.rs
@@ -5,12 +5,13 @@
 use super::{Denom, SCHEMA};
 use crate::{
     error::{Error, ErrorKind},
+    map,
     prelude::*,
+    Map,
 };
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use sha2::{Digest, Sha256};
 use std::{
-    collections::BTreeMap as Map,
     convert::TryFrom,
     fmt::{self, Display},
 };
@@ -143,6 +144,11 @@ impl ExchangeRates {
         );
 
         Ok(())
+    }
+
+    /// Iterate over the exchange rates
+    pub fn iter(&self) -> map::Iter<'_, Denom, Decimal> {
+        self.0.iter()
     }
 }
 


### PR DESCRIPTION
This commit removes all `dbg!` statements in the hot path and replaces them with an `info!` statement which logs the oracle vote.

Example output:

<img width="839" alt="Screen Shot 2020-10-19 at 2 27 52 PM" src="https://user-images.githubusercontent.com/37432020/96514965-51282580-1219-11eb-9d44-5ef823682d70.png">