### PR TITLE
Add `ListenConfig` + refactor router

### DIFF
--- a/delphi.toml.example
+++ b/delphi.toml.example
@@ -1,6 +1,12 @@
 # Example Delphi configuration file
 
-# HTTPS configuration
+# Listen address configuration
+[listen]
+addr = "127.0.0.1"
+port = 3822
+protocol = "http"
+
+# HTTPS client configuration
 # [https]
 # proxy = "https://webproxy.example.com:8080" # send outgoing requests through proxy
 

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -1,6 +1,6 @@
 //! `start` subcommand
 
-use crate::{application::APPLICATION, router};
+use crate::{application::APPLICATION, router::Router};
 use abscissa_core::{prelude::*, Command, Options, Runnable};
 use std::process;
 
@@ -11,7 +11,14 @@ pub struct StartCmd {}
 impl Runnable for StartCmd {
     /// Start the application.
     fn run(&self) {
-        abscissa_tokio::run(&APPLICATION, async { router::route().await }).unwrap_or_else(|e| {
+        // Initialize router from the app's configuration
+        let router = Router::init().unwrap_or_else(|e| {
+            status_err!("{}", e);
+            process::exit(1);
+        });
+
+        // Run the application
+        abscissa_tokio::run(&APPLICATION, async { router.route().await }).unwrap_or_else(|e| {
             status_err!("executor exited with error: {}", e);
             process::exit(1);
         });

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,10 +5,13 @@
 //! for specifying it.
 
 pub mod https;
+pub mod listen;
 pub mod network;
 pub mod source;
 
-pub use self::{https::HttpsConfig, network::NetworkConfig, source::SourceConfig};
+pub use self::{
+    https::HttpsConfig, listen::ListenConfig, network::NetworkConfig, source::SourceConfig,
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -16,11 +19,15 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DelphiConfig {
-    /// HTTPS configuration
+    /// Listen configuration
+    #[serde(default)]
+    pub listen: ListenConfig,
+
+    /// HTTPS client configuration
     #[serde(default)]
     pub https: HttpsConfig,
 
-    /// Network configuration
+    /// Network (i.e. chain) configuration
     #[serde(default)]
     pub network: NetworkConfig,
 

--- a/src/config/listen.rs
+++ b/src/config/listen.rs
@@ -1,0 +1,47 @@
+//! Listen config
+
+use serde::{Deserialize, Serialize};
+use std::net::Ipv4Addr;
+
+/// Default port number (38°28′56″ N, 22°30′4″ E)
+pub const DEFAULT_PORT: u16 = 3822;
+
+/// Listen config: control how Delphi listens on the network for requests
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ListenConfig {
+    /// IPv4 address to listen on
+    // TODO(tarcieri): IPv6
+    pub addr: Ipv4Addr,
+
+    /// Port to listen on
+    pub port: u16,
+
+    /// Protocol to listen on
+    pub protocol: Protocol,
+}
+
+impl Default for ListenConfig {
+    fn default() -> Self {
+        Self {
+            addr: Ipv4Addr::new(127, 0, 0, 1),
+            port: DEFAULT_PORT,
+            protocol: Protocol::default(),
+        }
+    }
+}
+
+/// Protocol to listen on
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+pub enum Protocol {
+    /// Plaintext HTTP
+    // TODO(tarcieri): HTTPS, gRPC
+    #[serde(rename = "http")]
+    Http,
+}
+
+impl Default for Protocol {
+    fn default() -> Self {
+        Protocol::Http
+    }
+}

--- a/src/router.rs
+++ b/src/router.rs
@@ -6,25 +6,83 @@
 //! curl -i -X POST -H "Content-Type: application/json" -d '{"network":"columbus-4"}' http://127.0.0.1:23456/oracles/terra
 //! ```
 
-use crate::networks::terra;
+use crate::{config::listen::Protocol, error::Error, networks::terra, prelude::*};
+use serde::Deserialize;
+use std::convert::Infallible;
+use tendermint::chain;
+use tendermint_rpc::endpoint::{broadcast::tx_commit, status::SyncInfo};
 use warp::Filter;
 
-/// Route incoming requests
-pub async fn route() {
-    // TODO(tarcieri): configure listen addr/port from config file
-    let listen_addr = [127, 0, 0, 1];
-    let listen_port = 23456;
+/// HTTP request router
+#[derive(Clone)]
+pub struct Router {
+    /// Address to listen on
+    addr: ([u8; 4], u16),
 
-    let terra_oracle = terra::ExchangeRateOracle::new();
-    let terra_oracle_filter = warp::any().map(move || terra_oracle.clone());
+    /// Protocol to listen on
+    protocol: Protocol,
 
-    let app = warp::post()
-        .and(warp::path("oracles"))
-        .and(warp::path("terra"))
-        .and(warp::path::end())
-        .and(terra_oracle_filter.clone())
-        .and(warp::body::json())
-        .and_then(terra::ExchangeRateOracle::handle_request);
+    /// Terra oracle
+    terra_oracle: terra::ExchangeRateOracle,
+}
 
-    warp::serve(app).run((listen_addr, listen_port)).await;
+impl Router {
+    /// Initialize the router from the config
+    pub fn init() -> Result<Router, Error> {
+        let config = app_config();
+        let addr = (config.listen.addr.octets(), config.listen.port);
+        let protocol = config.listen.protocol;
+        let terra_oracle = terra::ExchangeRateOracle::new(&config)?;
+        Ok(Self {
+            addr,
+            protocol,
+            terra_oracle,
+        })
+    }
+
+    /// Route incoming requests
+    pub async fn route(self) {
+        let addr = self.addr;
+        let protocol = self.protocol;
+        let terra_oracle_filter = warp::any().map(move || self.terra_oracle.clone());
+
+        let app = warp::post()
+            .and(warp::path("oracle"))
+            .and(warp::path::end())
+            .and(terra_oracle_filter.clone())
+            .and(warp::body::json())
+            .and_then(oracle_request);
+
+        match protocol {
+            Protocol::Http => warp::serve(app).run(addr).await,
+        }
+    }
+}
+
+/// `POST /oracle` - handle incoming oracle requests
+///
+/// This endpoint is intended to be triggered by Tendermint KMS
+pub async fn oracle_request(
+    oracle: terra::ExchangeRateOracle,
+    req: Request,
+) -> Result<impl warp::Reply, Infallible> {
+    // TODO(tarcieri): dispatch incoming requests based on chain ID
+    oracle.handle_request(req).await
+}
+
+/// Incoming oracle requests from Tendermint KMS (serialized as JSON)
+#[derive(Clone, Debug, Deserialize)]
+pub struct Request {
+    /// Chain ID
+    pub network: chain::Id,
+
+    /// Arbitrary context string to pass to transaction source
+    #[serde(default)]
+    pub context: String,
+
+    /// Network status
+    pub status: Option<SyncInfo>,
+
+    /// Response from last signed TX (if available)
+    pub last_tx_response: Option<tx_commit::Response>,
 }


### PR DESCRIPTION
Adds a new `ListenConfig` struct which allows configuring the address, port, and protocol (presently limited to "http") to listen on.

Additionally does some refactoring around the way configuration is processed in order to make the config accessible earlier in the application lifecycle.