### PR TITLE
Adding new fiat currencies to Terra

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423"
+checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
 dependencies = [
  "gimli",
 ]
@@ -96,15 +96,21 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.34"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
+checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-trait"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -124,21 +130,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
-
-[[package]]
-name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.54"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2baad346b2d4e94a24347adeee9c7a93f412ee94b9cc26e5b59dea23848e9f28"
+checksum = "9d117600f438b1707d4e4ae15d3595657288f8235a0eb593e80ecc98ab34e1bc"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
@@ -159,6 +159,12 @@ name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
@@ -231,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.4.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+checksum = "099e596ef14349721d9016f6b80dd3419ea1bf289ab9b44df8e4dfd3a005d5d9"
 
 [[package]]
 name = "byte-tools"
@@ -243,15 +249,21 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "canonical-path"
@@ -261,9 +273,9 @@ checksum = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
 
 [[package]]
 name = "cc"
-version = "1.0.62"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cfg-if"
@@ -289,15 +301,6 @@ dependencies = [
  "serde",
  "time",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -367,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4666154fd004af3fd6f1da2e81a96fd5a81927fe8ddb6ecc79e2aa6e138b54"
+checksum = "f9d58633299b24b515ac72a3f869f8b91306a3cec616a602843a383acd6f9e97"
 dependencies = [
  "bstr",
  "csv-core",
@@ -398,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
+checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
@@ -450,7 +453,7 @@ version = "0.0.0"
 dependencies = [
  "abscissa_core",
  "abscissa_tokio",
- "bytes",
+ "bytes 0.5.6",
  "csv",
  "futures",
  "gumdrop",
@@ -493,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "dtoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
+checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
 
 [[package]]
 name = "ecdsa"
@@ -614,12 +617,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,15 +634,15 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "funty"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba62103ce691c2fd80fbae2213dfdda9ce60804973ac6b6e97de818ea7f52c8"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
+checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -658,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
+checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -668,15 +665,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
+checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -685,15 +682,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
+checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -703,24 +700,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
+checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
 
 [[package]]
 name = "futures-task"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
+checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
+checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -729,7 +726,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 1.0.1",
+ "pin-project-lite 0.2.4",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -766,13 +763,24 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -818,7 +826,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -840,13 +848,13 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "headers"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed18eb2459bf1a09ad2d6b1547840c3e5e62882fa09b9a6a20b1de8e3228848f"
+checksum = "62689dc57c7456e69712607ffcbd0aa1dfcccf9af73727e9b25bc1825375cac3"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.0",
  "bitflags",
- "bytes",
+ "bytes 1.0.1",
  "headers-core",
  "http",
  "mime",
@@ -865,9 +873,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
@@ -884,11 +892,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "fnv",
  "itoa",
 ]
@@ -899,15 +907,15 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "http",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.3.4"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
 
 [[package]]
 name = "httpdate"
@@ -921,7 +929,7 @@ version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -931,7 +939,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.1",
+ "pin-project 1.0.4",
  "socket2",
  "tokio",
  "tower-service",
@@ -945,7 +953,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93ec5be69758dfc06b9b29efa9d6e9306e387c85eb362c603912eead2ad98c7"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures",
  "http",
  "hyper",
@@ -963,7 +971,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "ct-logs",
  "futures-util",
  "hyper",
@@ -981,7 +989,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "hyper",
  "native-tls",
  "tokio",
@@ -1007,11 +1015,11 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "hashbrown",
 ]
 
@@ -1021,7 +1029,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
 ]
 
 [[package]]
@@ -1053,15 +1061,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1096,17 +1104,17 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1159,14 +1167,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
 dependencies = [
  "adler",
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
 name = "mio"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
 dependencies = [
  "cfg-if 0.1.10",
  "fuchsia-zircon",
@@ -1183,9 +1191,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
  "net2",
@@ -1195,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "multipart"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8209c33c951f07387a8497841122fc6f712165e3f9bda3e6be4645b58188f676"
+checksum = "d050aeedc89243f5347c3e237e3e13dc76fbe4ae3742a57b94dc14f69acf76d4"
 dependencies = [
  "buf_redux",
  "httparse",
@@ -1205,7 +1213,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "quick-error",
- "rand 0.6.5",
+ "rand 0.7.3",
  "safemem",
  "tempfile",
  "twoway",
@@ -1213,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcc7939b5edc4e4f86b1b4a04bb1498afaaf871b1a6691838ed06fcb48d3a3f"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1231,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.35"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -1257,7 +1265,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "num-traits",
 ]
 
@@ -1267,7 +1275,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
 ]
 
 [[package]]
@@ -1282,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
+checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "once_cell"
@@ -1306,12 +1314,12 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.30"
+version = "0.10.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
+checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
 dependencies = [
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "foreign-types",
  "lazy_static",
  "libc",
@@ -1326,11 +1334,11 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.58"
+version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg",
  "cc",
  "libc",
  "pkg-config",
@@ -1363,11 +1371,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
+checksum = "95b70b68509f17aa2857863b6fa00bf21fc93674c7a8893de2f469f6aa7ca2f2"
 dependencies = [
- "pin-project-internal 1.0.1",
+ "pin-project-internal 1.0.4",
 ]
 
 [[package]]
@@ -1383,9 +1391,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
+checksum = "caa25a6393f22ce819b0f50e0be89287292fda8d425be38ee0ca14c4931d9e71"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1397,6 +1405,12 @@ name = "pin-project-lite"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "pin-utils"
@@ -1424,9 +1438,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -1443,7 +1457,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "prost-derive",
 ]
 
@@ -1454,7 +1468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dda006a6c21ae45e261a5a756f2a3e5299722eedae2405f4747dd6a5b47556e"
 dependencies = [
  "byteorder",
- "bytes",
+ "bytes 0.5.6",
 ]
 
 [[package]]
@@ -1490,7 +1504,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "prost",
 ]
 
@@ -1502,9 +1516,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
  "proc-macro2",
 ]
@@ -1517,30 +1531,11 @@ checksum = "64de9a0c5361e034f1aefc9f71a86871ec870e766fe31a009734a989b329286a"
 
 [[package]]
 name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.7",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg",
- "rand_xorshift",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
@@ -1548,13 +1543,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.1.1"
+name = "rand"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.3.1",
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.1",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -1568,19 +1565,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.3.1"
+name = "rand_chacha"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
- "rand_core 0.4.2",
+ "ppv-lite86",
+ "rand_core 0.6.1",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1588,16 +1580,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.1.0"
+name = "rand_core"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
 dependencies = [
- "rand_core 0.3.1",
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -1610,78 +1602,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_isaac"
-version = "0.1.1"
+name = "rand_hc"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.7",
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
+ "rand_core 0.6.1",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1701,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "remove_dir_all"
@@ -1716,9 +1658,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.15"
+version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
  "cc",
  "libc",
@@ -1731,10 +1673,11 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e81662973c7a8d9663e64a0de4cd642b89a21d64966e3d99606efdc5fb0cc6"
+checksum = "04d1fde955d206c00af1eb529d8ebfca3b505921820a0436566dbcc6c4d4ffb3"
 dependencies = [
+ "arrayvec",
  "num-traits",
  "serde",
 ]
@@ -1781,6 +1724,15 @@ name = "safemem"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1882,9 +1834,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.117"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
 dependencies = [
  "serde_derive",
 ]
@@ -1900,9 +1852,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.117"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1911,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "itoa",
  "ryu",
@@ -1957,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3cdf1b5e620a498ee6f2a171885ac7e22f0e12089ec4b3d22b84921792507c"
+checksum = "f4b312c3731e3fe78a185e6b9b911a7aa715b8e31cce117975219aab2acf285d"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
@@ -1970,9 +1922,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
+checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
@@ -1983,9 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604508c1418b99dfe1925ca9224829bb2a8a9a04dda655cc01fcad46f4ab05ed"
+checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1993,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
+checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
 dependencies = [
  "libc",
 ]
@@ -2018,22 +1970,21 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
 dependencies = [
  "maybe-uninit",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.3.16"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd8b795c389288baa5f355489c65e71fd48a02104600d15c4cfbc561e9e429d"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
  "winapi 0.3.9",
 ]
 
@@ -2077,9 +2028,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "subtle"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "subtle-encoding"
@@ -2092,9 +2043,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.48"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2115,13 +2066,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "rand 0.7.3",
+ "rand 0.8.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -2129,13 +2080,13 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.17.0-rc3"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469c73d90e4f6ae15f68e2475db9e7cd3ebcf71321d30910acefa92b83c70804"
+checksum = "dece4b481502a8dc31696b7656b97dd73fba374112c22a9a9dae2dcae47231ac"
 dependencies = [
  "anomaly",
  "async-trait",
- "bytes",
+ "bytes 0.5.6",
  "chrono",
  "ed25519",
  "ed25519-dalek",
@@ -2160,12 +2111,12 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.17.0-rc3"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e38abad428d9414b61b20a252441a04dff48daf68e9562352f10201df5a3cb6"
+checksum = "1dc89e2c7de21f1abb9ae5bc7eb5570b10a3ec11ca0a7a009ec594b1d3b8c917"
 dependencies = [
  "anomaly",
- "bytes",
+ "bytes 0.5.6",
  "chrono",
  "num-derive",
  "num-traits",
@@ -2179,13 +2130,14 @@ dependencies = [
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.17.0-rc2"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7fe6420a7c17e890c3c3744afa2908efbb4effb0832ecb0570929b33f79f73a"
+checksum = "777930720ed2ade8198dcbaddcfbeaf8528215de3d4641d806ff1e42952a8d3c"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "chrono",
- "getrandom",
+ "getrandom 0.1.16",
+ "pin-project 1.0.4",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -2194,31 +2146,32 @@ dependencies = [
  "tendermint-proto",
  "thiserror",
  "uuid",
+ "walkdir",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2227,29 +2180,28 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "d8208a331e1cb318dd5bd76951d2b8fc48ca38a69f5f4e4af1b6a9f8c6236915"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78a366903f506d2ad52ca8dc552102ffdd3e937ba8a227f024dc1d1eae28575"
+checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2262,11 +2214,11 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.23"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
+checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "iovec",
@@ -2274,7 +2226,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "slab",
  "tokio-macros",
 ]
@@ -2331,38 +2283,38 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "tokio",
 ]
 
 [[package]]
 name = "toml"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "tower-service"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
+checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.2.4",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -2439,13 +2391,13 @@ checksum = "f0308d80d86700c5878b9ef6321f020f29b1bb9d5ff3cab25e75e23f3a492a23"
 dependencies = [
  "base64 0.12.3",
  "byteorder",
- "bytes",
+ "bytes 0.5.6",
  "http",
  "httparse",
  "input_buffer",
  "log",
  "rand 0.7.3",
- "sha-1 0.9.2",
+ "sha-1 0.9.3",
  "url",
  "utf-8",
 ]
@@ -2466,7 +2418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3179a61e9eccceead5f1574fd173cf2e162ac42638b9bf214c6ad0baf7efa24a"
 dependencies = [
  "base64 0.11.0",
- "bytes",
+ "bytes 0.5.6",
  "chrono",
  "http",
  "mime",
@@ -2498,9 +2450,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f98e67a4d84f730d343392f9bfff7d21e3fca562b9cb7a43b768350beeddc6"
+checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
 dependencies = [
  "tinyvec",
 ]
@@ -2543,15 +2495,15 @@ checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
 
 [[package]]
 name = "uuid"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "vcpkg"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "version_check"
@@ -2566,6 +2518,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file",
+ "winapi 0.3.9",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2584,7 +2547,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f41be6df54c97904af01aa23e613d4521eed7ab23537cede692d4058f6449407"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures",
  "headers",
  "http",
@@ -2614,25 +2577,25 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.68"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
+checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.68"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
+checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2645,9 +2608,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.68"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2655,9 +2618,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.68"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
+checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2668,15 +2631,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.68"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
 
 [[package]]
 name = "web-sys"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
+checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2684,9 +2647,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",
@@ -2753,9 +2716,9 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "zeroize"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"
+checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
 dependencies = [
  "zeroize_derive",
 ]

--- a/src/currency.rs
+++ b/src/currency.rs
@@ -58,6 +58,9 @@ pub enum Currency {
     ///Chinese Yuan
     Cny,
 
+    ///Japanese Yen
+    Jpy,
+
     /// Other (open-ended)
     Other(String),
 }
@@ -82,6 +85,7 @@ impl Display for Currency {
             Currency::Sdr => "SDR",
             Currency::Mnt => "MNT",
             Currency::Cny => "CNY",
+            Currency::Jpy => "JPY",
         })
     }
 }
@@ -106,6 +110,7 @@ impl FromStr for Currency {
             "USDT" => Currency::Usdt,
             "SDR" => Currency::Sdr,
             "CNY" => Currency::Cny,
+            "JPY" => Currency::Jpy,
             other => Currency::Other(other.to_owned()),
         })
     }
@@ -147,6 +152,7 @@ impl Currency {
             Currency::Usdt => "N/A".to_string(),
             Currency::Mnt => "N/A".to_string(),
             Currency::Cny => "N/A".to_string(),
+            Currency::Jpy => "N/A".to_string(),
         }
     }
 }

--- a/src/currency.rs
+++ b/src/currency.rs
@@ -61,6 +61,9 @@ pub enum Currency {
     ///Japanese Yen
     Jpy,
 
+    ///Indian Rupee
+    Inr,
+
     /// Other (open-ended)
     Other(String),
 }
@@ -86,6 +89,7 @@ impl Display for Currency {
             Currency::Mnt => "MNT",
             Currency::Cny => "CNY",
             Currency::Jpy => "JPY",
+            Currency::Inr => "INR",
         })
     }
 }
@@ -111,6 +115,7 @@ impl FromStr for Currency {
             "SDR" => Currency::Sdr,
             "CNY" => Currency::Cny,
             "JPY" => Currency::Jpy,
+            "INR" => Currency::Inr,
             other => Currency::Other(other.to_owned()),
         })
     }
@@ -153,6 +158,7 @@ impl Currency {
             Currency::Mnt => "N/A".to_string(),
             Currency::Cny => "N/A".to_string(),
             Currency::Jpy => "N/A".to_string(),
+            Currency::Inr => "N/A".to_string(),
         }
     }
 }

--- a/src/currency.rs
+++ b/src/currency.rs
@@ -13,6 +13,9 @@ pub enum Currency {
     /// Cosmos Atom
     Atom,
 
+    ///Australian Dollar
+    Aud,
+
     /// Binance Coin
     Bnb,
 
@@ -102,6 +105,7 @@ impl Display for Currency {
             Currency::Jpy => "JPY",
             Currency::Inr => "INR",
             Currency::Hkd => "HKD",
+            Currency::Aud => "AUD",
         })
     }
 }
@@ -131,6 +135,7 @@ impl FromStr for Currency {
             "CAD" => Currency::Cad,
             "CHF" => Currency::Chf,
             "HKD" => Currency::Hkd,
+            "AUD" => Currency::Aud,
             other => Currency::Other(other.to_owned()),
         })
     }
@@ -177,6 +182,7 @@ impl Currency {
             Currency::Cad => "N/A".to_string(),
             Currency::Chf => "N/A".to_string(),
             Currency::Hkd => "N/A".to_string(),
+            Currency::Aud => "N/A".to_string(),
         }
     }
 }

--- a/src/currency.rs
+++ b/src/currency.rs
@@ -1,5 +1,6 @@
 //! Currency support (i.e. assets)
 
+use crate::networks::terra::denom::Denom;
 use crate::Error;
 use serde::{de, ser, Deserialize, Serialize};
 use std::{
@@ -143,6 +144,27 @@ impl FromStr for Currency {
             "SGD" => Currency::Sgd,
             other => Currency::Other(other.to_owned()),
         })
+    }
+}
+
+impl From<Denom> for Currency {
+    fn from(denom: Denom) -> Currency {
+        match denom {
+            Denom::UEUR => Currency::Eur,
+            Denom::UCNY => Currency::Cny,
+            Denom::UJPY => Currency::Jpy,
+            Denom::UGBP => Currency::Gbp,
+            Denom::UINR => Currency::Inr,
+            Denom::UCAD => Currency::Cad,
+            Denom::UCHF => Currency::Chf,
+            Denom::UHKD => Currency::Hkd,
+            Denom::UAUD => Currency::Aud,
+            Denom::USGD => Currency::Sgd,
+            Denom::UKRW => Currency::Krw,
+            Denom::UMNT => Currency::Mnt,
+            Denom::USDR => Currency::Sdr,
+            Denom::UUSD => Currency::Usd,
+        }
     }
 }
 

--- a/src/currency.rs
+++ b/src/currency.rs
@@ -67,6 +67,9 @@ pub enum Currency {
     /// IMF Special Drawing Rights
     Sdr,
 
+    ///Singapore Dollar
+    Sgd,
+
     /// US dollars
     Usd,
 
@@ -106,6 +109,7 @@ impl Display for Currency {
             Currency::Inr => "INR",
             Currency::Hkd => "HKD",
             Currency::Aud => "AUD",
+            Currency::Sgd => "SGD",
         })
     }
 }
@@ -136,6 +140,7 @@ impl FromStr for Currency {
             "CHF" => Currency::Chf,
             "HKD" => Currency::Hkd,
             "AUD" => Currency::Aud,
+            "SGD" => Currency::Sgd,
             other => Currency::Other(other.to_owned()),
         })
     }
@@ -183,6 +188,7 @@ impl Currency {
             Currency::Chf => "N/A".to_string(),
             Currency::Hkd => "N/A".to_string(),
             Currency::Aud => "N/A".to_string(),
+            Currency::Sgd => "N/A".to_string(),
         }
     }
 }

--- a/src/currency.rs
+++ b/src/currency.rs
@@ -25,6 +25,12 @@ pub enum Currency {
     /// Binance USD stablecoin
     Busd,
 
+    ///Canadian Dollar
+    Cad,
+
+    ///Chinese Yuan
+    Cny,
+
     /// Ethereum
     Eth,
 
@@ -34,11 +40,23 @@ pub enum Currency {
     /// UK Pounds
     Gbp,
 
+    ///Indian Rupee
+    Inr,
+
+    ///Japanese Yen
+    Jpy,
+
     /// South Korean won
     Krw,
 
     /// Terra Luna
     Luna,
+
+    /// Mongolian Tugrik
+    Mnt,
+
+    /// IMF Special Drawing Rights
+    Sdr,
 
     /// US dollars
     Usd,
@@ -48,21 +66,6 @@ pub enum Currency {
 
     /// Tether USDT stablecoin
     Usdt,
-
-    /// IMF Special Drawing Rights
-    Sdr,
-
-    /// Mongolian Tugrik
-    Mnt,
-
-    ///Chinese Yuan
-    Cny,
-
-    ///Japanese Yen
-    Jpy,
-
-    ///Indian Rupee
-    Inr,
 
     /// Other (open-ended)
     Other(String),
@@ -90,6 +93,7 @@ impl Display for Currency {
             Currency::Cny => "CNY",
             Currency::Jpy => "JPY",
             Currency::Inr => "INR",
+            Currency::Cad => "CAD",
         })
     }
 }
@@ -116,6 +120,7 @@ impl FromStr for Currency {
             "CNY" => Currency::Cny,
             "JPY" => Currency::Jpy,
             "INR" => Currency::Inr,
+            "CAD" => Currency::Cad,
             other => Currency::Other(other.to_owned()),
         })
     }
@@ -159,6 +164,7 @@ impl Currency {
             Currency::Cny => "N/A".to_string(),
             Currency::Jpy => "N/A".to_string(),
             Currency::Inr => "N/A".to_string(),
+            Currency::Cad => "N/A".to_string(),
         }
     }
 }

--- a/src/currency.rs
+++ b/src/currency.rs
@@ -55,6 +55,9 @@ pub enum Currency {
     /// Mongolian Tugrik
     Mnt,
 
+    ///Chinese Yuan
+    Cny,
+
     /// Other (open-ended)
     Other(String),
 }
@@ -78,6 +81,7 @@ impl Display for Currency {
             Currency::Other(other) => other.as_ref(),
             Currency::Sdr => "SDR",
             Currency::Mnt => "MNT",
+            Currency::Cny => "CNY",
         })
     }
 }
@@ -101,6 +105,7 @@ impl FromStr for Currency {
             "USDC" => Currency::Usdc,
             "USDT" => Currency::Usdt,
             "SDR" => Currency::Sdr,
+            "CNY" => Currency::Cny,
             other => Currency::Other(other.to_owned()),
         })
     }
@@ -141,6 +146,7 @@ impl Currency {
             Currency::Usdc => "N/A".to_string(),
             Currency::Usdt => "N/A".to_string(),
             Currency::Mnt => "N/A".to_string(),
+            Currency::Cny => "N/A".to_string(),
         }
     }
 }

--- a/src/currency.rs
+++ b/src/currency.rs
@@ -43,6 +43,9 @@ pub enum Currency {
     /// UK Pounds
     Gbp,
 
+    ///Hong Kong Dollar
+    Hkd,
+
     ///Indian Rupee
     Inr,
 
@@ -98,6 +101,7 @@ impl Display for Currency {
             Currency::Cny => "CNY",
             Currency::Jpy => "JPY",
             Currency::Inr => "INR",
+            Currency::Hkd => "HKD",
         })
     }
 }
@@ -126,6 +130,7 @@ impl FromStr for Currency {
             "INR" => Currency::Inr,
             "CAD" => Currency::Cad,
             "CHF" => Currency::Chf,
+            "HKD" => Currency::Hkd,
             other => Currency::Other(other.to_owned()),
         })
     }
@@ -171,6 +176,7 @@ impl Currency {
             Currency::Inr => "N/A".to_string(),
             Currency::Cad => "N/A".to_string(),
             Currency::Chf => "N/A".to_string(),
+            Currency::Hkd => "N/A".to_string(),
         }
     }
 }

--- a/src/currency.rs
+++ b/src/currency.rs
@@ -28,6 +28,9 @@ pub enum Currency {
     ///Canadian Dollar
     Cad,
 
+    ///Swiss Franc
+    Chf,
+
     ///Chinese Yuan
     Cny,
 
@@ -79,6 +82,8 @@ impl Display for Currency {
             Currency::Bkrw => "BKRW",
             Currency::Btc => "BTC",
             Currency::Busd => "BUSD",
+            Currency::Cad => "CAD",
+            Currency::Chf => "CHF",
             Currency::Eth => "ETH",
             Currency::Eur => "EUR",
             Currency::Gbp => "GBP",
@@ -93,7 +98,6 @@ impl Display for Currency {
             Currency::Cny => "CNY",
             Currency::Jpy => "JPY",
             Currency::Inr => "INR",
-            Currency::Cad => "CAD",
         })
     }
 }
@@ -121,6 +125,7 @@ impl FromStr for Currency {
             "JPY" => Currency::Jpy,
             "INR" => Currency::Inr,
             "CAD" => Currency::Cad,
+            "CHF" => Currency::Chf,
             other => Currency::Other(other.to_owned()),
         })
     }
@@ -165,6 +170,7 @@ impl Currency {
             Currency::Jpy => "N/A".to_string(),
             Currency::Inr => "N/A".to_string(),
             Currency::Cad => "N/A".to_string(),
+            Currency::Chf => "N/A".to_string(),
         }
     }
 }

--- a/src/networks/terra/denom.rs
+++ b/src/networks/terra/denom.rs
@@ -54,6 +54,9 @@ pub enum Denom {
 
     ///Hong Kong Dollar
     UHKD,
+
+    ///Australian Dollar
+    UAUD,
 }
 
 impl Denom {
@@ -72,6 +75,7 @@ impl Denom {
             Denom::UCAD,
             Denom::UCHF,
             Denom::UHKD,
+            Denom::UAUD,
         ]
     }
 
@@ -90,6 +94,7 @@ impl Denom {
             Denom::UCAD => "ucad",
             Denom::UCHF => "uchf",
             Denom::UHKD => "uhkd",
+            Denom::UAUD => "uaud",
         }
     }
 
@@ -296,6 +301,22 @@ impl Denom {
 
                 luna_hkd.rescale(18);
                 Ok(luna_hkd.try_into()?)
+            }
+
+            Denom::UAUD => {
+                let (alphavantage_response_usd, binance_response) = try_join!(
+                    sources
+                        .alphavantage
+                        .trading_pairs(&TradingPair(Currency::Usd, Currency::Aud)),
+                    sources
+                        .binance
+                        .approx_price_for_pair(&TradingPair(Currency::Luna, Currency::Usd)),
+                )?;
+
+                let mut luna_aud = Decimal::from(binance_response * alphavantage_response_usd);
+
+                luna_aud.rescale(18);
+                Ok(luna_aud.try_into()?)
             }
         }
     }

--- a/src/networks/terra/denom.rs
+++ b/src/networks/terra/denom.rs
@@ -51,6 +51,9 @@ pub enum Denom {
 
     ///Swiss Franc
     UCHF,
+
+    ///Hong Kong Dollar
+    UHKD,
 }
 
 impl Denom {
@@ -68,6 +71,7 @@ impl Denom {
             Denom::UINR,
             Denom::UCAD,
             Denom::UCHF,
+            Denom::UHKD,
         ]
     }
 
@@ -85,6 +89,7 @@ impl Denom {
             Denom::UINR => "uinr",
             Denom::UCAD => "ucad",
             Denom::UCHF => "uchf",
+            Denom::UHKD => "uhkd",
         }
     }
 
@@ -275,6 +280,22 @@ impl Denom {
 
                 luna_chf.rescale(18);
                 Ok(luna_chf.try_into()?)
+            }
+
+            Denom::UHKD => {
+                let (alphavantage_response_usd, binance_response) = try_join!(
+                    sources
+                        .alphavantage
+                        .trading_pairs(&TradingPair(Currency::Usd, Currency::Hkd)),
+                    sources
+                        .binance
+                        .approx_price_for_pair(&TradingPair(Currency::Luna, Currency::Usd)),
+                )?;
+
+                let mut luna_hkd = Decimal::from(binance_response * alphavantage_response_usd);
+
+                luna_hkd.rescale(18);
+                Ok(luna_hkd.try_into()?)
             }
         }
     }

--- a/src/networks/terra/denom.rs
+++ b/src/networks/terra/denom.rs
@@ -184,21 +184,7 @@ impl Denom {
 
             Denom::UCNY => luna_rate_via_usd(sources, self.into()).await,
 
-            Denom::UJPY => luna_rate_via_usd(sources, self.into()).await,
-
-            Denom::UGBP => luna_rate_via_usd(sources, self.into()).await,
-
-            Denom::UINR => luna_rate_via_usd(sources, self.into()).await,
-
-            Denom::UCAD => luna_rate_via_usd(sources, self.into()).await,
-
-            Denom::UCHF => luna_rate_via_usd(sources, self.into()).await,
-
-            Denom::UHKD => luna_rate_via_usd(sources, self.into()).await,
-
-            Denom::UAUD => luna_rate_via_usd(sources, self.into()).await,
-
-            Denom::USGD => luna_rate_via_usd(sources, self.into()).await,
+            _ => luna_rate_via_usd(sources, self.into()).await
         }
     }
 }

--- a/src/networks/terra/denom.rs
+++ b/src/networks/terra/denom.rs
@@ -180,167 +180,43 @@ impl Denom {
                 Ok(luna_sdr.try_into()?)
             }
 
-            Denom::UEUR => {
-                let (alphavantage_response_usd, binance_response) = try_join!(
-                    sources
-                        .alphavantage
-                        .trading_pairs(&TradingPair(Currency::Usd, Currency::Eur)),
-                    sources
-                        .binance
-                        .approx_price_for_pair(&TradingPair(Currency::Luna, Currency::Usd)),
-                )?;
+            Denom::UEUR => luna_rate_via_usd(sources, Currency::Eur).await,
 
-                let mut luna_eur = Decimal::from(binance_response * alphavantage_response_usd);
+            Denom::UCNY => luna_rate_via_usd(sources, Currency::Cny).await,
 
-                luna_eur.rescale(18);
-                Ok(luna_eur.try_into()?)
-            }
+            Denom::UJPY => luna_rate_via_usd(sources, Currency::Jpy).await,
 
-            Denom::UCNY => {
-                let (alphavantage_response_usd, binance_response) = try_join!(
-                    sources
-                        .alphavantage
-                        .trading_pairs(&TradingPair(Currency::Usd, Currency::Cny)),
-                    sources
-                        .binance
-                        .approx_price_for_pair(&TradingPair(Currency::Luna, Currency::Usd)),
-                )?;
+            Denom::UGBP => luna_rate_via_usd(sources, Currency::Gbp).await,
 
-                let mut luna_cny = Decimal::from(binance_response * alphavantage_response_usd);
+            Denom::UINR => luna_rate_via_usd(sources, Currency::Inr).await,
 
-                luna_cny.rescale(18);
-                Ok(luna_cny.try_into()?)
-            }
+            Denom::UCAD => luna_rate_via_usd(sources, Currency::Cad).await,
 
-            Denom::UJPY => {
-                let (alphavantage_response_usd, binance_response) = try_join!(
-                    sources
-                        .alphavantage
-                        .trading_pairs(&TradingPair(Currency::Usd, Currency::Jpy)),
-                    sources
-                        .binance
-                        .approx_price_for_pair(&TradingPair(Currency::Luna, Currency::Usd)),
-                )?;
+            Denom::UCHF => luna_rate_via_usd(sources, Currency::Chf).await,
 
-                let mut luna_jpy = Decimal::from(binance_response * alphavantage_response_usd);
+            Denom::UHKD => luna_rate_via_usd(sources, Currency::Hkd).await,
 
-                luna_jpy.rescale(18);
-                Ok(luna_jpy.try_into()?)
-            }
+            Denom::UAUD => luna_rate_via_usd(sources, Currency::Aud).await,
 
-            Denom::UGBP => {
-                let (alphavantage_response_usd, binance_response) = try_join!(
-                    sources
-                        .alphavantage
-                        .trading_pairs(&TradingPair(Currency::Usd, Currency::Gbp)),
-                    sources
-                        .binance
-                        .approx_price_for_pair(&TradingPair(Currency::Luna, Currency::Usd)),
-                )?;
-
-                let mut luna_gbp = Decimal::from(binance_response * alphavantage_response_usd);
-
-                luna_gbp.rescale(18);
-                Ok(luna_gbp.try_into()?)
-            }
-
-            Denom::UINR => {
-                let (alphavantage_response_usd, binance_response) = try_join!(
-                    sources
-                        .alphavantage
-                        .trading_pairs(&TradingPair(Currency::Usd, Currency::Inr)),
-                    sources
-                        .binance
-                        .approx_price_for_pair(&TradingPair(Currency::Luna, Currency::Usd)),
-                )?;
-
-                let mut luna_inr = Decimal::from(binance_response * alphavantage_response_usd);
-
-                luna_inr.rescale(18);
-                Ok(luna_inr.try_into()?)
-            }
-
-            Denom::UCAD => {
-                let (alphavantage_response_usd, binance_response) = try_join!(
-                    sources
-                        .alphavantage
-                        .trading_pairs(&TradingPair(Currency::Usd, Currency::Cad)),
-                    sources
-                        .binance
-                        .approx_price_for_pair(&TradingPair(Currency::Luna, Currency::Usd)),
-                )?;
-
-                let mut luna_cad = Decimal::from(binance_response * alphavantage_response_usd);
-
-                luna_cad.rescale(18);
-                Ok(luna_cad.try_into()?)
-            }
-
-            Denom::UCHF => {
-                let (alphavantage_response_usd, binance_response) = try_join!(
-                    sources
-                        .alphavantage
-                        .trading_pairs(&TradingPair(Currency::Usd, Currency::Chf)),
-                    sources
-                        .binance
-                        .approx_price_for_pair(&TradingPair(Currency::Luna, Currency::Usd)),
-                )?;
-
-                let mut luna_chf = Decimal::from(binance_response * alphavantage_response_usd);
-
-                luna_chf.rescale(18);
-                Ok(luna_chf.try_into()?)
-            }
-
-            Denom::UHKD => {
-                let (alphavantage_response_usd, binance_response) = try_join!(
-                    sources
-                        .alphavantage
-                        .trading_pairs(&TradingPair(Currency::Usd, Currency::Hkd)),
-                    sources
-                        .binance
-                        .approx_price_for_pair(&TradingPair(Currency::Luna, Currency::Usd)),
-                )?;
-
-                let mut luna_hkd = Decimal::from(binance_response * alphavantage_response_usd);
-
-                luna_hkd.rescale(18);
-                Ok(luna_hkd.try_into()?)
-            }
-
-            Denom::UAUD => {
-                let (alphavantage_response_usd, binance_response) = try_join!(
-                    sources
-                        .alphavantage
-                        .trading_pairs(&TradingPair(Currency::Usd, Currency::Aud)),
-                    sources
-                        .binance
-                        .approx_price_for_pair(&TradingPair(Currency::Luna, Currency::Usd)),
-                )?;
-
-                let mut luna_aud = Decimal::from(binance_response * alphavantage_response_usd);
-
-                luna_aud.rescale(18);
-                Ok(luna_aud.try_into()?)
-            }
-
-            Denom::USGD => {
-                let (alphavantage_response_usd, binance_response) = try_join!(
-                    sources
-                        .alphavantage
-                        .trading_pairs(&TradingPair(Currency::Usd, Currency::Sgd)),
-                    sources
-                        .binance
-                        .approx_price_for_pair(&TradingPair(Currency::Luna, Currency::Usd)),
-                )?;
-
-                let mut luna_sgd = Decimal::from(binance_response * alphavantage_response_usd);
-
-                luna_sgd.rescale(18);
-                Ok(luna_sgd.try_into()?)
-            }
+            Denom::USGD => luna_rate_via_usd(sources, Currency::Sgd).await,
         }
     }
+}
+
+async fn luna_rate_via_usd(sources: &Sources, cur: Currency) -> Result<stdtx::Decimal, Error> {
+    let pair_1 = TradingPair(Currency::Usd, cur);
+
+    let (alphavantage_response_usd, binance_response) = try_join!(
+        sources.alphavantage.trading_pairs(&pair_1),
+        sources
+            .binance
+            .approx_price_for_pair(&TradingPair(Currency::Luna, Currency::Usd)),
+    )?;
+
+    let mut luna_cur = Decimal::from(binance_response * alphavantage_response_usd);
+
+    luna_cur.rescale(18);
+    Ok(luna_cur.try_into()?)
 }
 
 impl Display for Denom {

--- a/src/networks/terra/denom.rs
+++ b/src/networks/terra/denom.rs
@@ -180,25 +180,25 @@ impl Denom {
                 Ok(luna_sdr.try_into()?)
             }
 
-            Denom::UEUR => luna_rate_via_usd(sources, Currency::Eur).await,
+            Denom::UEUR => luna_rate_via_usd(sources, self.into()).await,
 
-            Denom::UCNY => luna_rate_via_usd(sources, Currency::Cny).await,
+            Denom::UCNY => luna_rate_via_usd(sources, self.into()).await,
 
-            Denom::UJPY => luna_rate_via_usd(sources, Currency::Jpy).await,
+            Denom::UJPY => luna_rate_via_usd(sources, self.into()).await,
 
-            Denom::UGBP => luna_rate_via_usd(sources, Currency::Gbp).await,
+            Denom::UGBP => luna_rate_via_usd(sources, self.into()).await,
 
-            Denom::UINR => luna_rate_via_usd(sources, Currency::Inr).await,
+            Denom::UINR => luna_rate_via_usd(sources, self.into()).await,
 
-            Denom::UCAD => luna_rate_via_usd(sources, Currency::Cad).await,
+            Denom::UCAD => luna_rate_via_usd(sources, self.into()).await,
 
-            Denom::UCHF => luna_rate_via_usd(sources, Currency::Chf).await,
+            Denom::UCHF => luna_rate_via_usd(sources, self.into()).await,
 
-            Denom::UHKD => luna_rate_via_usd(sources, Currency::Hkd).await,
+            Denom::UHKD => luna_rate_via_usd(sources, self.into()).await,
 
-            Denom::UAUD => luna_rate_via_usd(sources, Currency::Aud).await,
+            Denom::UAUD => luna_rate_via_usd(sources, self.into()).await,
 
-            Denom::USGD => luna_rate_via_usd(sources, Currency::Sgd).await,
+            Denom::USGD => luna_rate_via_usd(sources, self.into()).await,
         }
     }
 }

--- a/src/networks/terra/denom.rs
+++ b/src/networks/terra/denom.rs
@@ -180,11 +180,7 @@ impl Denom {
                 Ok(luna_sdr.try_into()?)
             }
 
-            Denom::UEUR => luna_rate_via_usd(sources, self.into()).await,
-
-            Denom::UCNY => luna_rate_via_usd(sources, self.into()).await,
-
-            _ => luna_rate_via_usd(sources, self.into()).await
+            _ => luna_rate_via_usd(sources, self.into()).await,
         }
     }
 }

--- a/src/networks/terra/denom.rs
+++ b/src/networks/terra/denom.rs
@@ -42,6 +42,9 @@ pub enum Denom {
 
     /// UK Pound
     UGBP,
+
+    ///Indian Rupee
+    UINR,
 }
 
 impl Denom {
@@ -56,6 +59,7 @@ impl Denom {
             Denom::UCNY,
             Denom::UJPY,
             Denom::UGBP,
+            Denom::UINR,
         ]
     }
 
@@ -70,6 +74,7 @@ impl Denom {
             Denom::UCNY => "ucny",
             Denom::UJPY => "ujpy",
             Denom::UGBP => "ugbp",
+            Denom::UINR => "uinr",
         }
     }
 
@@ -213,6 +218,22 @@ impl Denom {
                 luna_gbp.rescale(18);
                 Ok(luna_gbp.try_into()?)
             }
+
+            Denom::UINR => {
+                let (alphavantage_response_usd, binance_response) = try_join!(
+                    sources
+                        .alphavantage
+                        .trading_pairs(&TradingPair(Currency::Usd, Currency::Inr)),
+                    sources
+                        .binance
+                        .approx_price_for_pair(&TradingPair(Currency::Luna, Currency::Usd)),
+                )?;
+
+                let mut luna_inr = Decimal::from(binance_response * alphavantage_response_usd);
+
+                luna_inr.rescale(18);
+                Ok(luna_inr.try_into()?)
+            }
         }
     }
 }
@@ -236,6 +257,7 @@ impl FromStr for Denom {
             "ucny" => Ok(Denom::UCNY),
             "ujpy" => Ok(Denom::UJPY),
             "ugbp" => Ok(Denom::UGBP),
+            "uinr" => Ok(Denom::UINR),
             _ => fail!(ErrorKind::Currency, "unknown Terra denom: {}", s),
         }
     }

--- a/src/networks/terra/denom.rs
+++ b/src/networks/terra/denom.rs
@@ -39,6 +39,9 @@ pub enum Denom {
 
     /// Japanese Yen
     UJPY,
+
+    /// UK Pound
+    UGBP,
 }
 
 impl Denom {
@@ -52,6 +55,7 @@ impl Denom {
             Denom::UEUR,
             Denom::UCNY,
             Denom::UJPY,
+            Denom::UGBP,
         ]
     }
 
@@ -65,6 +69,7 @@ impl Denom {
             Denom::UEUR => "ueur",
             Denom::UCNY => "ucny",
             Denom::UJPY => "ujpy",
+            Denom::UGBP => "ugbp",
         }
     }
 
@@ -192,6 +197,22 @@ impl Denom {
                 luna_jpy.rescale(18);
                 Ok(luna_jpy.try_into()?)
             }
+
+            Denom::UGBP => {
+                let (alphavantage_response_usd, binance_response) = try_join!(
+                    sources
+                        .alphavantage
+                        .trading_pairs(&TradingPair(Currency::Usd, Currency::Gbp)),
+                    sources
+                        .binance
+                        .approx_price_for_pair(&TradingPair(Currency::Luna, Currency::Usd)),
+                )?;
+
+                let mut luna_gbp = Decimal::from(binance_response * alphavantage_response_usd);
+
+                luna_gbp.rescale(18);
+                Ok(luna_gbp.try_into()?)
+            }
         }
     }
 }
@@ -214,6 +235,7 @@ impl FromStr for Denom {
             "ueur" => Ok(Denom::UEUR),
             "ucny" => Ok(Denom::UCNY),
             "ujpy" => Ok(Denom::UJPY),
+            "ugbp" => Ok(Denom::UGBP),
             _ => fail!(ErrorKind::Currency, "unknown Terra denom: {}", s),
         }
     }

--- a/src/networks/terra/denom.rs
+++ b/src/networks/terra/denom.rs
@@ -57,6 +57,9 @@ pub enum Denom {
 
     ///Australian Dollar
     UAUD,
+
+    ///Singapore Dollar
+    USGD,
 }
 
 impl Denom {
@@ -76,6 +79,7 @@ impl Denom {
             Denom::UCHF,
             Denom::UHKD,
             Denom::UAUD,
+            Denom::USGD,
         ]
     }
 
@@ -95,6 +99,7 @@ impl Denom {
             Denom::UCHF => "uchf",
             Denom::UHKD => "uhkd",
             Denom::UAUD => "uaud",
+            Denom::USGD => "usgd",
         }
     }
 
@@ -317,6 +322,22 @@ impl Denom {
 
                 luna_aud.rescale(18);
                 Ok(luna_aud.try_into()?)
+            }
+
+            Denom::USGD => {
+                let (alphavantage_response_usd, binance_response) = try_join!(
+                    sources
+                        .alphavantage
+                        .trading_pairs(&TradingPair(Currency::Usd, Currency::Sgd)),
+                    sources
+                        .binance
+                        .approx_price_for_pair(&TradingPair(Currency::Luna, Currency::Usd)),
+                )?;
+
+                let mut luna_sgd = Decimal::from(binance_response * alphavantage_response_usd);
+
+                luna_sgd.rescale(18);
+                Ok(luna_sgd.try_into()?)
             }
         }
     }


### PR DESCRIPTION
Adding the following fiat currencies to Terra - CNY, JPY, GBP, INR, CAD, CHF, HKD, AUD, SGD
