### PR TITLE
Add `terra.oracle.v1beta1` protobuf definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bip32"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d0f0fc59c7ba0333eed9dcc1b6980baa7b7a4dc7c6c5885994d0674f7adf34"
+dependencies = [
+ "bs58",
+ "hkd32",
+ "hmac",
+ "k256",
+ "ripemd160",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,7 +170,23 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
+ "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+
+[[package]]
+name = "bs58"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+dependencies = [
+ "sha2",
 ]
 
 [[package]]
@@ -269,6 +301,37 @@ name = "core-foundation-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+
+[[package]]
+name = "cosmos-sdk-proto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "676c5bae3939f3a7cbda3ff160fdcf85bbc997cb95dde092c2709099077564d8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tendermint-proto",
+]
+
+[[package]]
+name = "cosmrs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfe09c1bd2a2caca692d37fc7f728d38b77c03ac15c83e018857e1e36deca416"
+dependencies = [
+ "bip32",
+ "cosmos-sdk-proto",
+ "ecdsa",
+ "eyre",
+ "getrandom 0.2.3",
+ "k256",
+ "prost",
+ "prost-types",
+ "rand_core 0.6.3",
+ "subtle-encoding",
+ "tendermint",
+ "thiserror",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -387,6 +450,7 @@ dependencies = [
  "abscissa_core",
  "abscissa_tokio",
  "bytes 1.1.0",
+ "cosmrs",
  "csv",
  "eyre",
  "futures",
@@ -394,6 +458,7 @@ dependencies = [
  "iqhttp",
  "once_cell",
  "percent-encoding",
+ "prost",
  "rand 0.8.4",
  "rust_decimal",
  "serde",
@@ -682,8 +747,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -780,6 +847,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "hkd32"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84f2a5541afe0725f0b95619d6af614f48c1b176385b8aa30918cfb8c4bfafc8"
+dependencies = [
+ "hmac",
+ "once_cell",
+ "pbkdf2",
+ "rand_core 0.6.3",
+ "sha2",
+ "zeroize",
 ]
 
 [[package]]
@@ -1005,7 +1086,14 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "sha2",
+ "sha3",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "lazy_static"
@@ -1281,6 +1369,15 @@ name = "paste"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+
+[[package]]
+name = "pbkdf2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
+dependencies = [
+ "crypto-mac",
+]
 
 [[package]]
 name = "peg"
@@ -1603,6 +1700,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd160"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "opaque-debug",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,6 +1944,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "keccak",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1991,10 +2111,12 @@ dependencies = [
  "ed25519-dalek",
  "flex-error",
  "futures",
+ "k256",
  "num-traits",
  "once_cell",
  "prost",
  "prost-types",
+ "ripemd160",
  "serde",
  "serde_bytes",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ categories  = ["cryptography::cryptocurrencies"]
 abscissa_core = "=0.6.0-pre.1"
 abscissa_tokio = "=0.6.0-pre.1"
 bytes = "1"
+cosmrs = "0.2"
 eyre = "0.6"
 gumdrop = "0.7"
 iqhttp = { version = "0.1", features = ["json", "proxy"] }
@@ -26,6 +27,7 @@ percent-encoding = "2.1"
 rand = "0.8"
 rust_decimal = "1"
 once_cell = "1"
+prost = "0.7"
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 sha2 = "0.9"

--- a/src/networks/terra.rs
+++ b/src/networks/terra.rs
@@ -4,6 +4,7 @@
 pub mod denom;
 pub mod msg;
 pub mod oracle;
+pub mod proto;
 
 pub use self::{denom::Denom, oracle::ExchangeRateOracle};
 

--- a/src/networks/terra/proto.rs
+++ b/src/networks/terra/proto.rs
@@ -1,0 +1,60 @@
+//! Terra Oracle Protobuf Definitions
+//!
+//! Protobuf definitions:
+//! <https://github.com/terra-money/core/blob/main/proto/terra/oracle/v1beta1/oracle.proto>
+
+use cosmrs::tx::MsgProto;
+use prost::Message;
+
+/// Struct for aggregate prevoting on the ExchangeRateVote.
+///
+/// The purpose of aggregate prevote is to hide vote exchange rates with hash
+/// which is formatted as hex string in
+/// `SHA256("{salt}:{exchange rate}{denom},...,{exchange rate}{denom}:{voter}")`
+#[derive(Clone, PartialEq, Message)]
+pub struct AggregateExchangeRatePrevote {
+    /// Commitment to future vote
+    #[prost(string, tag = "1")]
+    pub hash: String,
+
+    /// Origin Address for vote
+    #[prost(string, tag = "2")]
+    pub voter: String,
+
+    /// Submit block
+    #[prost(uint64, tag = "3")]
+    pub submit_block: u64,
+}
+
+impl MsgProto for AggregateExchangeRatePrevote {
+    const TYPE_URL: &'static str = "/terra.oracle.v1beta1.AggregateExchangeRatePrevote";
+}
+
+/// MsgAggregateExchangeRateVote - struct for voting on
+/// the exchange rates of Luna denominated in various Terra assets.
+#[derive(Clone, PartialEq, Message)]
+pub struct AggregateExchangeRateVote {
+    /// Exchange rate tuples
+    #[prost(message, repeated, tag = "1")]
+    pub exchange_rate_tuples: Vec<ExchangeRateTuple>,
+
+    /// Origin Address for vote
+    #[prost(string, tag = "2")]
+    pub voter: String,
+}
+
+impl MsgProto for AggregateExchangeRateVote {
+    const TYPE_URL: &'static str = "/terra.oracle.v1beta1.AggregateExchangeRateVote";
+}
+
+/// ExchangeRateTuple - struct to store interpreted exchange rates data to store
+#[derive(Clone, PartialEq, Message)]
+pub struct ExchangeRateTuple {
+    /// Denomination
+    #[prost(string, tag = "1")]
+    pub denom: String,
+
+    /// Exchange rate
+    #[prost(string, tag = "2")]
+    pub exchange_rate: String,
+}


### PR DESCRIPTION
Sourced from:

https://github.com/terra-money/core/blob/main/proto/terra/oracle/v1beta1/oracle.proto

Manually translated to `prost-derive` syntax.